### PR TITLE
fix AuthorizeUrl exception in PHP 7.4+

### DIFF
--- a/src/Connect/AuthorizeUrl.php
+++ b/src/Connect/AuthorizeUrl.php
@@ -264,7 +264,7 @@ class AuthorizeUrl implements Arrayable
     {
         return collect($this->all())->reject(function ($value) {
             return is_null($value);
-        });
+        })->toArray();
     }
 
 }


### PR DESCRIPTION
Hi thanks for publishing your work on this!

Here's a fix for an exception when generating the oauth url, occuring when it gets to https://github.com/stripe/stripe-php/blob/7f516261bc496706a03b9443107532b552efa9d8/lib/OAuth.php#L83.

```
array_key_exists(): Using array_key_exists() on objects is deprecated. Use isset() or property_exists() instead
```