### PR TITLE
Fix issue with wrongly configured hasMany relationship definition

### DIFF
--- a/src/Connect/OwnsStripeAccounts.php
+++ b/src/Connect/OwnsStripeAccounts.php
@@ -57,7 +57,7 @@ trait OwnsStripeAccounts
 
         return $this->hasMany(
             get_class($model),
-            $this->getForeignKey(),
+            'owner_id',
             $this->getStripeIdentifierName()
         );
     }

--- a/tests/lib/Integration/Connect/AuthorizeTest.php
+++ b/tests/lib/Integration/Connect/AuthorizeTest.php
@@ -86,6 +86,9 @@ class AuthorizeTest extends TestCase
             $this->assertTrue($this->user->is($event->owner), 'event owner');
             return true;
         });
+
+        $this->assertNotNull($relationship = $this->user->stripeAccounts->first());
+        $this->assertInstanceOf(StripeAccount::class, $relationship);
     }
 
     /**


### PR DESCRIPTION
First of all, thank you for providing high quality code in your packages. It's been a delight using both your JSON API package and this one!

I believe I found an issue with the definition of the StripeAccounts relationship of the OwnsStripeAccounts trait. 

I have added a passing test, which fails without the fix. Let me know if you would require more info on this issue.

Best regards,

Ciaro