### PR TITLE
Fix #12 scope not being present when using express login

### DIFF
--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -96,7 +96,7 @@ class OAuthController extends Controller
     {
         event($success = new OAuthSuccess(
             $data['code'],
-            $data['scope'],
+            $data['scope']?? 'express', // No scope is present when using express, so we need to manually set it here
             $user,
             Config::connectSuccessView()
         ));

--- a/src/Http/Requests/AuthorizeConnect.php
+++ b/src/Http/Requests/AuthorizeConnect.php
@@ -44,7 +44,7 @@ class AuthorizeConnect extends FormRequest
                 'string',
             ],
             'scope' => [
-                'required_with:code',
+                'sometimes',
                 Rule::in(AuthorizeUrl::scopes()),
             ],
             'error' => [


### PR DESCRIPTION
Fixes issue #12 by providing a default express scope when using express login.

Signed-off-by: marcorivm <marcorivm@gmail.com>